### PR TITLE
Reduce number of tests by one, to make count match up

### DIFF
--- a/t/23_universal_require.t
+++ b/t/23_universal_require.t
@@ -55,7 +55,7 @@ all_pod_files_ok();},[qw(strict Test::More Test::Pod Test::Pod::Coverage)]],
    );
 
 
-plan tests => (scalar @tests)+1;
+plan tests => (scalar @tests);
 
 
 foreach my $t (@tests) {


### PR DESCRIPTION
Seems the removal of Test::NoWarnings forgot to remove a +1, which makes the 23_universal_require.t fail for me. Removing the +1 makes all tests pass again
