### PR TITLE
Whitespace is valid

### DIFF
--- a/lib/Module/ExtractUse.pm
+++ b/lib/Module/ExtractUse.pm
@@ -147,8 +147,8 @@ sub extract_use {
 
         next unless $result;
 
-        foreach (split(/ /,$result)) {
-            $self->_add($_);
+        foreach (split(/\s+/,$result)) {
+            $self->_add($_) if($_);
         }
     }
 

--- a/t/23_universal_require.t
+++ b/t/23_universal_require.t
@@ -43,6 +43,7 @@ my @tests=
    ['use base ("Class::DBI6","Foo::Bar7");',[qw(Class::DBI6 Foo::Bar7)]],
 #26
    ['use base "Class::DBI8","Foo::Bar9";',[qw(Class::DBI8 Foo::Bar9)]],
+   ['use base qw(   Class::DBI10   Foo::Bar11   );',[qw(Class::DBI10 Foo::Bar11)]],
    ['eval "use Test::Pod 1.06";',['Test::Pod']],
    [q{#!/usr/bin/perl -w
 use strict;


### PR DESCRIPTION
A few of my modules have been failing on CPANTS due to odd "(eval?)" errors. It turns out that because I use whitespace within my quoting, e.g. "use base qw( Data::Phrasebook::Loader::Base Data::Phrasebook::Debug );", the extra whitespace is flagged as an extra use call.

The patch is to split on all whitespace, and don't add to the list unless we actually have content.
