### PR TITLE
Fix the case for eval["']expr["'] and add regression tests.

### DIFF
--- a/lib/Module/ExtractUse.pm
+++ b/lib/Module/ExtractUse.pm
@@ -116,7 +116,7 @@ sub extract_use {
         my $result;
 
         # check for string eval in ' ', " " strings
-        if ($statement !~ s/eval\s+(['"])(.*?)\1/$2;/) {
+        if ($statement !~ s/eval\s*(['"])(.*?)\1/$2;/) {
             # if that didn't work, try q and qq strings
             if ($statement !~ s/eval\s+qq?(\S)(.*?)\1/$2;/) {
                 # finally try paired delims like qq< >, q( ), ...

--- a/t/22_eval.t
+++ b/t/22_eval.t
@@ -1,4 +1,4 @@
-use Test::More tests => 9;
+use Test::More tests => 11;
 
 use strict;
 use warnings;
@@ -76,3 +76,18 @@ eval 'use Test::Pod $ver';};
 }
 
 
+{
+    my $semi   = 'eval"use Test::Pod 1.00;";';
+    my $p = Module::ExtractUse->new;
+    $p->extract_use( \$semi );
+
+    ok( $p->used( 'Test::Pod' ), 'no spaces between eval and expr with semicolon' );
+}
+
+{
+    my $nosemi = "eval'use Test::Pod 1.00';";
+    my $p = Module::ExtractUse->new;
+    $p->extract_use( \$nosemi );
+
+    ok( $p->used( 'Test::Pod' ), 'no spaces between eval and expr w/o semicolon' );
+}


### PR DESCRIPTION
eval EXPR could be no spaces between eval and EXPR for the case of eval'string'. However, the following regexp is used:

```
s/eval\s+(['"])(.*?)\1/$2;/
```

It should be

```
s/eval\s*(['"])(.*?)\1/$2;/
```

Corresponding tests are added.

NOTE: I am working on another pull request. If this pull request is accepted, I will make another one soon.
