### PR TITLE
Detect eval context

### DIFF
--- a/lib/Module/ExtractUse.pm
+++ b/lib/Module/ExtractUse.pm
@@ -35,19 +35,19 @@ use version; our $VERSION=version->new('0.29');
   my @used=$p->array;
   my $used=$p->string;
   
-  # you can get optional, that is in eval context, use in the same style
-  my $used=$p->optional_used;           # $used is a HASHREF
-  print $p->optional_used('strict')     # true if code includes 'use strict'
+  # you can get optional modules, that is use in eval context, in the same style
+  my $used=$p->used_in_eval;           # $used is a HASHREF
+  print $p->used_in_eval('strict')     # true if code includes 'use strict'
   
-  my @used=$p->optional_array;
-  my $used=$p->optional_string;
+  my @used=$p->array_in_eval;
+  my $used=$p->string_in_eval;
   
-  # and mandatory, that is outside eval context, use in the same style, also.
-  my $used=$p->mandatory_used;           # $used is a HASHREF
-  print $p->mandatory_used('strict')     # true if code includes 'use strict'
+  # and mandatory modules, that is use out of eval context, in the same style, also.
+  my $used=$p->used_out_of_eval;           # $used is a HASHREF
+  print $p->used_out_of_eval('strict')     # true if code includes 'use strict'
   
-  my @used=$p->mandatory_array;
-  my $used=$p->mandatory_string;
+  my @used=$p->array_out_of_eval;
+  my $used=$p->string_out_of_eval;
 
 =head1 DESCRIPTION
 
@@ -234,26 +234,26 @@ sub used {
     return $self->{found};
 }
 
-=head3 optional_used
+=head3 used_in_eval
 
 Same as C<used>, except for considering in-eval-context only.
 
 =cut
 
-sub optional_used {
+sub used_in_eval {
     my $self=shift;
     my $key=shift;
     return $self->{found_in_eval}{$key} if ($key);
     return $self->{found_in_eval};
 }
 
-=head3 mandatory_used
+=head3 used_out_of_eval
 
 Same as C<used>, except for considering NOT-in-eval-context only.
 
 =cut
 
-sub mandatory_used {
+sub used_out_of_eval {
     my $self=shift;
     my $key=shift;
     return $self->{found_not_in_eval}{$key} if ($key);
@@ -277,25 +277,25 @@ sub string {
     return join($sep,sort keys(%{$self->{found}}));
 }
 
-=head3 optional_string
+=head3 string_in_eval
 
 Same as C<string>, except for considering in-eval-context only.
 
 =cut
 
-sub optional_string {
+sub string_in_eval {
     my $self=shift;
     my $sep=shift || ' ';
     return join($sep,sort keys(%{$self->{found_in_eval}}));
 }
 
-=head3 mandatory_string
+=head3 string_out_of_eval
 
 Same as C<string>, except for considering NOT-in-eval-context only.
 
 =cut
 
-sub mandatory_string {
+sub string_out_of_eval {
     my $self=shift;
     my $sep=shift || ' ';
     return join($sep,sort keys(%{$self->{found_not_in_eval}}));
@@ -313,23 +313,23 @@ sub array {
     return keys(%{shift->{found}})
 }
 
-=head3 optional_array
+=head3 array_in_eval
 
 Same as C<array>, except for considering in-eval-context only.
 
 =cut
 
-sub optional_array {
+sub array_in_eval {
     return keys(%{shift->{found_in_eval}})
 }
 
-=head3 mandatory_array
+=head3 array_out_of_eval
 
 Same as C<array>, except for considering NOT-in-eval-context only.
 
 =cut
 
-sub mandatory_array {
+sub array_out_of_eval {
     return keys(%{shift->{found_not_in_eval}})
 }
 
@@ -347,26 +347,26 @@ sub arrayref {
     return;
 }
 
-=head3 optional_arrayref
+=head3 arrayref_in_eval
 
 Same as C<array_ref>, except for considering in-eval-context only.
 
 =cut
 
-sub optional_arrayref {
-    my @a=shift->optional_array;
+sub arrayref_in_eval {
+    my @a=shift->array_in_eval;
     return \@a if @a;
     return;
 }
 
-=head3 mandatory_arrayref
+=head3 arrayref_out_of_eval
 
 Same as C<array_ref>, except for considering NOT-in-eval-context only.
 
 =cut
 
-sub mandatory_arrayref {
-    my @a=shift->mandatory_array;
+sub arrayref_out_of_eval {
+    my @a=shift->array_out_of_eval;
     return \@a if @a;
     return;
 }

--- a/t/10_basic.t
+++ b/t/10_basic.t
@@ -88,8 +88,8 @@ foreach my $t (@tests) {
     my $p=Module::ExtractUse->new;
     my @used = (
         $p->extract_use(\$code)->arrayref || undef,
-        $p->extract_use(\$code)->optional_arrayref || undef,
-        $p->extract_use(\$code)->mandatory_arrayref || undef,
+        $p->extract_use(\$code)->arrayref_in_eval || undef,
+        $p->extract_use(\$code)->arrayref_out_of_eval || undef,
     );
 
     for(my $i = 0; $i < @used; ++$i) {

--- a/t/20_parse_self.t
+++ b/t/20_parse_self.t
@@ -13,12 +13,12 @@ use Module::ExtractUse;
 	       bag(qw(strict Test::More Test::Deep Test::NoWarnings Module::ExtractUse)),
 	       'modules used in this test script'
 	      );
-    @used=$p->extract_use($0)->optional_array;
+    @used=$p->extract_use($0)->array_in_eval;
     cmp_deeply(\@used,
 	       [],
 	       'optional modules used in this test script'
 	      );
-    @used=$p->extract_use($0)->mandatory_array;
+    @used=$p->extract_use($0)->array_out_of_eval;
     cmp_deeply(\@used,
 	       bag(qw(strict Test::More Test::Deep Test::NoWarnings Module::ExtractUse)),
 	       'mandatory modules used in this test script'
@@ -32,10 +32,10 @@ use Module::ExtractUse;
     cmp_deeply($p->arrayref,
 	       bag(qw(strict warnings Pod::Strip Parse::RecDescent Module::ExtractUse::Grammar Carp 5.008)),
 	       'modules used in this Module::ExtractUsed');
-    cmp_deeply([$p->optional_arrayref],
+    cmp_deeply([$p->arrayref_in_eval],
 	       [],
 	       'optional modules used in this Module::ExtractUsed');
-    cmp_deeply($p->mandatory_arrayref,
+    cmp_deeply($p->arrayref_out_of_eval,
 	       bag(qw(strict warnings Pod::Strip Parse::RecDescent Module::ExtractUse::Grammar Carp 5.008)),
 	       'mandatory modules used in this Module::ExtractUsed');
 
@@ -44,15 +44,15 @@ use Module::ExtractUse;
 
     is($p->used('strict'),1,'strict via used method');
 
-    my $optional_used=$p->optional_used;
-    is(!$optional_used->{'strict'},1,'strict via optional hash lookup');
+    my $used_in_eval=$p->used_in_eval;
+    is(!$used_in_eval->{'strict'},1,'strict via in-eval hash lookup');
 
-    is(!$p->optional_used('strict'),1,'strict via optional_used method');
+    is(!$p->used_in_eval('strict'),1,'strict via used_in_eval method');
 
-    my $mandatory_used=$p->mandatory_used;
-    is($mandatory_used->{'strict'},1,'strict via mandatory hash lookup');
+    my $used_out_of_eval=$p->used_out_of_eval;
+    is($used_out_of_eval->{'strict'},1,'strict via out-of-eval hash lookup');
 
-    is($p->mandatory_used('strict'),1,'strict via mandatory_used method');
+    is($p->used_out_of_eval('strict'),1,'strict via used_out_of_eval method');
 
 }
 

--- a/t/22_eval.t
+++ b/t/22_eval.t
@@ -11,8 +11,8 @@ use Module::ExtractUse;
     $p->extract_use( \$semi );
 
     ok( $p->used( 'Test::Pod' ) );
-    ok( $p->optional_used( 'Test::Pod' ) );
-    ok(!$p->mandatory_used( 'Test::Pod' ) );
+    ok( $p->used_in_eval( 'Test::Pod' ) );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ) );
 }
 
 {
@@ -21,8 +21,8 @@ use Module::ExtractUse;
     $p->extract_use( \$nosemi );
 
     ok( $p->used( 'Test::Pod' ) );
-    ok( $p->optional_used( 'Test::Pod' ) );
-    ok(!$p->mandatory_used( 'Test::Pod' ) );
+    ok( $p->used_in_eval( 'Test::Pod' ) );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ) );
 }
 
 {
@@ -30,8 +30,8 @@ use Module::ExtractUse;
     my $p = Module::ExtractUse->new;
     $p->extract_use( \$qq );
     ok( $p->used( 'Test::Pod' ), 'qq brace' );
-    ok( $p->optional_used( 'Test::Pod' ), 'qq brace' );
-    ok(!$p->mandatory_used( 'Test::Pod' ), 'qq brace' );
+    ok( $p->used_in_eval( 'Test::Pod' ), 'qq brace' );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ), 'qq brace' );
 }
 
 {
@@ -39,8 +39,8 @@ use Module::ExtractUse;
     my $p = Module::ExtractUse->new;
     $p->extract_use( \$qq );
     ok( $p->used( 'Test::Pod' ), 'qq plus' );
-    ok( $p->optional_used( 'Test::Pod' ), 'qq plus' );
-    ok(!$p->mandatory_used( 'Test::Pod' ), 'qq plus' );
+    ok( $p->used_in_eval( 'Test::Pod' ), 'qq plus' );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ), 'qq plus' );
 }
 
 {
@@ -48,8 +48,8 @@ use Module::ExtractUse;
     my $p = Module::ExtractUse->new;
     $p->extract_use( \$qq );
     ok( $p->used( 'Test::Pod' ), 'qq paren' );
-    ok( $p->optional_used( 'Test::Pod' ), 'qq paren' );
-    ok(!$p->mandatory_used( 'Test::Pod' ), 'qq paren' );
+    ok( $p->used_in_eval( 'Test::Pod' ), 'qq paren' );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ), 'qq paren' );
 }
 
 {
@@ -57,8 +57,8 @@ use Module::ExtractUse;
     my $p = Module::ExtractUse->new;
     $p->extract_use( \$q );
     ok( $p->used( 'Test::Pod' ), 'q angle' );
-    ok( $p->optional_used( 'Test::Pod' ), 'q angle' );
-    ok(!$p->mandatory_used( 'Test::Pod' ), 'q angle' );
+    ok( $p->used_in_eval( 'Test::Pod' ), 'q angle' );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ), 'q angle' );
 }
 
 {
@@ -66,8 +66,8 @@ use Module::ExtractUse;
     my $p = Module::ExtractUse->new;
     $p->extract_use( \$q );
     ok( $p->used( 'Test::Pod' ), 'q slash' );
-    ok( $p->optional_used( 'Test::Pod' ), 'q slash' );
-    ok(!$p->mandatory_used( 'Test::Pod' ), 'q slash' );
+    ok( $p->used_in_eval( 'Test::Pod' ), 'q slash' );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ), 'q slash' );
 }
 
 # reported by DAGOLDEN@cpan.org as [rt.cpan.org #19302]
@@ -78,8 +78,8 @@ eval "use Test::Pod $ver;"};
     $p->extract_use( \$varversion );
 
     ok( $p->used( 'Test::Pod' ) );
-    ok( $p->optional_used( 'Test::Pod' ) );
-    ok(!$p->mandatory_used( 'Test::Pod' ) );
+    ok( $p->used_in_eval( 'Test::Pod' ) );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ) );
 }
 
 {
@@ -89,8 +89,8 @@ eval 'use Test::Pod $ver';};
     $p->extract_use( \$varversion );
 
     ok( $p->used( 'Test::Pod' ) );
-    ok( $p->optional_used( 'Test::Pod' ) );
-    ok(!$p->mandatory_used( 'Test::Pod' ) );
+    ok( $p->used_in_eval( 'Test::Pod' ) );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ) );
 }
 
 
@@ -100,8 +100,8 @@ eval 'use Test::Pod $ver';};
     $p->extract_use( \$semi );
 
     ok( $p->used( 'Test::Pod' ), 'no spaces between eval and expr with semicolon' );
-    ok( $p->optional_used( 'Test::Pod' ) );
-    ok(!$p->mandatory_used( 'Test::Pod' ) );
+    ok( $p->used_in_eval( 'Test::Pod' ) );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ) );
 }
 
 {
@@ -110,6 +110,6 @@ eval 'use Test::Pod $ver';};
     $p->extract_use( \$nosemi );
 
     ok( $p->used( 'Test::Pod' ), 'no spaces between eval and expr w/o semicolon' );
-    ok( $p->optional_used( 'Test::Pod' ) );
-    ok(!$p->mandatory_used( 'Test::Pod' ) );
+    ok( $p->used_in_eval( 'Test::Pod' ) );
+    ok(!$p->used_out_of_eval( 'Test::Pod' ) );
 }

--- a/t/23_universal_require.t
+++ b/t/23_universal_require.t
@@ -63,8 +63,8 @@ foreach my $t (@tests) {
     my $p=Module::ExtractUse->new;
     my @used = (
         $p->extract_use(\$code)->arrayref || undef,
-        $p->extract_use(\$code)->optional_arrayref || undef,
-        $p->extract_use(\$code)->mandatory_arrayref || undef,
+        $p->extract_use(\$code)->arrayref_in_eval || undef,
+        $p->extract_use(\$code)->arrayref_out_of_eval || undef,
     );
 
     for(my $i = 0; $i < @used; ++$i) {


### PR DESCRIPTION
This module is very useful and CPANTS uses it to calculate Kwalitee indicators like prereq_matches_use. As my understandings, CPANTS currently compares the result of this module with union of prereqs and optional prereqs.
If this module would detect optionality of using modules, that is use in eval context or out of eval context, we could check prereqs more precisely.

I added accessors with suffixes _in_eval / _out_of_eval, and tests for them.
