### PR TITLE
Fix handling module beginning with v and pragma with version.

### DIFF
--- a/grammar
+++ b/grammar
@@ -5,15 +5,12 @@
 token_use:		/\buse\s/ use_stuff /[;}]/
 		{ $return=$item{use_stuff} }
 
-use_stuff:	(base | parent | pragma | version | module)
+use_stuff:	(base | parent | version | module)
 
 base:		"base" import_list
 
 parent:		"parent" import_list
 		{ $return='parent'; $return.=' '.$item[2] if $item[2] !~ /^\s*-norequire\b/; }
-
-pragma:		/[a-z\d]+/ import_list
-		{ $return=$item[1]}
 
 module:		module_name module_more
 		{ $return=$item{module_name} }
@@ -43,7 +40,7 @@ require_name:	<perl_quotelike>
 # General Rules
 #-----------------------------------------------------------------
 
-version:	/[\d\._v]+/
+version:	/v?[\d\._]+/
 
 eos:		{ $text=~/^[\s;]+$/ ? 1 : undef;}
 

--- a/lib/Module/ExtractUse/Grammar.pm
+++ b/lib/Module/ExtractUse/Grammar.pm
@@ -1135,194 +1135,6 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::comma_list_item
 }
 
 # ARGS ARE: ($parser, $text; $repeating, $_noactions, \@args, $_itempos)
-sub Parse::RecDescent::Module::ExtractUse::Grammar::pragma
-{
-	my $thisparser = $_[0];
-	use vars q{$tracelevel};
-	local $tracelevel = ($tracelevel||0)+1;
-	$ERRORS = 0;
-    my $thisrule = $thisparser->{"rules"}{"pragma"};
-
-    Parse::RecDescent::_trace(q{Trying rule: [pragma]},
-                  Parse::RecDescent::_tracefirst($_[1]),
-                  q{pragma},
-                  $tracelevel)
-                    if defined $::RD_TRACE;
-
-    
-    my $err_at = @{$thisparser->{errors}};
-
-    my $score;
-    my $score_return;
-    my $_tok;
-    my $return = undef;
-    my $_matched=0;
-    my $commit=0;
-    my @item = ();
-    my %item = ();
-    my $repeating =  $_[2];
-    my $_noactions = $_[3];
-    my @arg =    defined $_[4] ? @{ &{$_[4]} } : ();
-    my $_itempos = $_[5];
-    my %arg =    ($#arg & 01) ? @arg : (@arg, undef);
-    my $text;
-    my $lastsep;
-    my $current_match;
-    my $expectation = new Parse::RecDescent::Expectation(q{/[a-z\\d]+/});
-    $expectation->at($_[1]);
-    
-    my $thisline;
-    tie $thisline, q{Parse::RecDescent::LineCounter}, \$text, $thisparser;
-
-    
-
-    while (!$_matched && !$commit)
-    {
-        
-        Parse::RecDescent::_trace(q{Trying production: [/[a-z\\d]+/ import_list]},
-                      Parse::RecDescent::_tracefirst($_[1]),
-                      q{pragma},
-                      $tracelevel)
-                        if defined $::RD_TRACE;
-        my $thisprod = $thisrule->{"prods"}[0];
-        $text = $_[1];
-        my $_savetext;
-        @item = (q{pragma});
-        %item = (__RULE__ => q{pragma});
-        my $repcount = 0;
-
-
-        Parse::RecDescent::_trace(q{Trying terminal: [/[a-z\\d]+/]}, Parse::RecDescent::_tracefirst($text),
-                      q{pragma},
-                      $tracelevel)
-                        if defined $::RD_TRACE;
-        undef $lastsep;
-        $expectation->is(q{})->at($text);
-        
-
-        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:[a-z\d]+)/)
-        {
-            $text = $lastsep . $text if defined $lastsep;
-            $expectation->failed();
-            Parse::RecDescent::_trace(q{<<Didn't match terminal>>},
-                          Parse::RecDescent::_tracefirst($text))
-                    if defined $::RD_TRACE;
-
-            last;
-        }
-        $current_match = substr($text, $-[0], $+[0] - $-[0]);
-        substr($text,0,length($current_match),q{});
-        Parse::RecDescent::_trace(q{>>Matched terminal<< (return value: [}
-                        . $current_match . q{])},
-                          Parse::RecDescent::_tracefirst($text))
-                    if defined $::RD_TRACE;
-        push @item, $item{__PATTERN1__}=$current_match;
-        
-
-        Parse::RecDescent::_trace(q{Trying subrule: [import_list]},
-                  Parse::RecDescent::_tracefirst($text),
-                  q{pragma},
-                  $tracelevel)
-                    if defined $::RD_TRACE;
-        if (1) { no strict qw{refs};
-        $expectation->is(q{import_list})->at($text);
-        unless (defined ($_tok = Parse::RecDescent::Module::ExtractUse::Grammar::import_list($thisparser,$text,$repeating,$_noactions,sub { \@arg },undef)))
-        {
-            
-            Parse::RecDescent::_trace(q{<<Didn't match subrule: [import_list]>>},
-                          Parse::RecDescent::_tracefirst($text),
-                          q{pragma},
-                          $tracelevel)
-                            if defined $::RD_TRACE;
-            $expectation->failed();
-            last;
-        }
-        Parse::RecDescent::_trace(q{>>Matched subrule: [import_list]<< (return value: [}
-                    . $_tok . q{]},
-
-                      Parse::RecDescent::_tracefirst($text),
-                      q{pragma},
-                      $tracelevel)
-                        if defined $::RD_TRACE;
-        $item{q{import_list}} = $_tok;
-        push @item, $_tok;
-        
-        }
-
-        Parse::RecDescent::_trace(q{Trying action},
-                      Parse::RecDescent::_tracefirst($text),
-                      q{pragma},
-                      $tracelevel)
-                        if defined $::RD_TRACE;
-        
-
-        $_tok = ($_noactions) ? 0 : do { $return=$item[1]};
-        unless (defined $_tok)
-        {
-            Parse::RecDescent::_trace(q{<<Didn't match action>> (return value: [undef])})
-                    if defined $::RD_TRACE;
-            last;
-        }
-        Parse::RecDescent::_trace(q{>>Matched action<< (return value: [}
-                      . $_tok . q{])},
-                      Parse::RecDescent::_tracefirst($text))
-                        if defined $::RD_TRACE;
-        push @item, $_tok;
-        $item{__ACTION1__}=$_tok;
-        
-
-        Parse::RecDescent::_trace(q{>>Matched production: [/[a-z\\d]+/ import_list]<<},
-                      Parse::RecDescent::_tracefirst($text),
-                      q{pragma},
-                      $tracelevel)
-                        if defined $::RD_TRACE;
-
-
-
-        $_matched = 1;
-        last;
-    }
-
-
-    unless ( $_matched || defined($score) )
-    {
-        
-
-        $_[1] = $text;  # NOT SURE THIS IS NEEDED
-        Parse::RecDescent::_trace(q{<<Didn't match rule>>},
-                     Parse::RecDescent::_tracefirst($_[1]),
-                     q{pragma},
-                     $tracelevel)
-                    if defined $::RD_TRACE;
-        return undef;
-    }
-    if (!defined($return) && defined($score))
-    {
-        Parse::RecDescent::_trace(q{>>Accepted scored production<<}, "",
-                      q{pragma},
-                      $tracelevel)
-                        if defined $::RD_TRACE;
-        $return = $score_return;
-    }
-    splice @{$thisparser->{errors}}, $err_at;
-    $return = $item[$#item] unless defined $return;
-    if (defined $::RD_TRACE)
-    {
-        Parse::RecDescent::_trace(q{>>Matched rule<< (return value: [} .
-                      $return . q{])}, "",
-                      q{pragma},
-                      $tracelevel);
-        Parse::RecDescent::_trace(q{(consumed: [} .
-                      Parse::RecDescent::_tracemax(substr($_[1],0,-length($text))) . q{])},
-                      Parse::RecDescent::_tracefirst($text),
-                      , q{pragma},
-                      $tracelevel)
-    }
-    $_[1] = $text;
-    return $return;
-}
-
-# ARGS ARE: ($parser, $text; $repeating, $_noactions, \@args, $_itempos)
 sub Parse::RecDescent::Module::ExtractUse::Grammar::module_more
 {
 	my $thisparser = $_[0];
@@ -2901,7 +2713,7 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::version
     my $text;
     my $lastsep;
     my $current_match;
-    my $expectation = new Parse::RecDescent::Expectation(q{/[\\d\\._v]+/});
+    my $expectation = new Parse::RecDescent::Expectation(q{/v?[\\d\\._]+/});
     $expectation->at($_[1]);
     
     my $thisline;
@@ -2912,7 +2724,7 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::version
     while (!$_matched && !$commit)
     {
         
-        Parse::RecDescent::_trace(q{Trying production: [/[\\d\\._v]+/]},
+        Parse::RecDescent::_trace(q{Trying production: [/v?[\\d\\._]+/]},
                       Parse::RecDescent::_tracefirst($_[1]),
                       q{version},
                       $tracelevel)
@@ -2925,7 +2737,7 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::version
         my $repcount = 0;
 
 
-        Parse::RecDescent::_trace(q{Trying terminal: [/[\\d\\._v]+/]}, Parse::RecDescent::_tracefirst($text),
+        Parse::RecDescent::_trace(q{Trying terminal: [/v?[\\d\\._]+/]}, Parse::RecDescent::_tracefirst($text),
                       q{version},
                       $tracelevel)
                         if defined $::RD_TRACE;
@@ -2933,7 +2745,7 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::version
         $expectation->is(q{})->at($text);
         
 
-        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:[\d\._v]+)/)
+        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:v?[\d\._]+)/)
         {
             $text = $lastsep . $text if defined $lastsep;
             $expectation->failed();
@@ -2952,7 +2764,7 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::version
         push @item, $item{__PATTERN1__}=$current_match;
         
 
-        Parse::RecDescent::_trace(q{>>Matched production: [/[\\d\\._v]+/]<<},
+        Parse::RecDescent::_trace(q{>>Matched production: [/v?[\\d\\._]+/]<<},
                       Parse::RecDescent::_tracefirst($text),
                       q{version},
                       $tracelevel)
@@ -3037,7 +2849,7 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::use_stuff
     my $text;
     my $lastsep;
     my $current_match;
-    my $expectation = new Parse::RecDescent::Expectation(q{base, or parent, or pragma, or version, or module});
+    my $expectation = new Parse::RecDescent::Expectation(q{base, or parent, or version, or module});
     $expectation->at($_[1]);
     
     my $thisline;
@@ -3048,7 +2860,7 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::use_stuff
     while (!$_matched && !$commit)
     {
         
-        Parse::RecDescent::_trace(q{Trying production: [base, or parent, or pragma, or version, or module]},
+        Parse::RecDescent::_trace(q{Trying production: [base, or parent, or version, or module]},
                       Parse::RecDescent::_tracefirst($_[1]),
                       q{use_stuff},
                       $tracelevel)
@@ -3091,7 +2903,7 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::use_stuff
         
         }
 
-        Parse::RecDescent::_trace(q{>>Matched production: [base, or parent, or pragma, or version, or module]<<},
+        Parse::RecDescent::_trace(q{>>Matched production: [base, or parent, or version, or module]<<},
                       Parse::RecDescent::_tracefirst($text),
                       q{use_stuff},
                       $tracelevel)
@@ -3499,7 +3311,7 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::_alternation_1_of_production
     my $text;
     my $lastsep;
     my $current_match;
-    my $expectation = new Parse::RecDescent::Expectation(q{base, or parent, or pragma, or version, or module});
+    my $expectation = new Parse::RecDescent::Expectation(q{base, or parent, or version, or module});
     $expectation->at($_[1]);
     
     my $thisline;
@@ -3628,71 +3440,12 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::_alternation_1_of_production
     while (!$_matched && !$commit)
     {
         
-        Parse::RecDescent::_trace(q{Trying production: [pragma]},
-                      Parse::RecDescent::_tracefirst($_[1]),
-                      q{_alternation_1_of_production_1_of_rule_use_stuff},
-                      $tracelevel)
-                        if defined $::RD_TRACE;
-        my $thisprod = $thisrule->{"prods"}[2];
-        $text = $_[1];
-        my $_savetext;
-        @item = (q{_alternation_1_of_production_1_of_rule_use_stuff});
-        %item = (__RULE__ => q{_alternation_1_of_production_1_of_rule_use_stuff});
-        my $repcount = 0;
-
-
-        Parse::RecDescent::_trace(q{Trying subrule: [pragma]},
-                  Parse::RecDescent::_tracefirst($text),
-                  q{_alternation_1_of_production_1_of_rule_use_stuff},
-                  $tracelevel)
-                    if defined $::RD_TRACE;
-        if (1) { no strict qw{refs};
-        $expectation->is(q{})->at($text);
-        unless (defined ($_tok = Parse::RecDescent::Module::ExtractUse::Grammar::pragma($thisparser,$text,$repeating,$_noactions,sub { \@arg },undef)))
-        {
-            
-            Parse::RecDescent::_trace(q{<<Didn't match subrule: [pragma]>>},
-                          Parse::RecDescent::_tracefirst($text),
-                          q{_alternation_1_of_production_1_of_rule_use_stuff},
-                          $tracelevel)
-                            if defined $::RD_TRACE;
-            $expectation->failed();
-            last;
-        }
-        Parse::RecDescent::_trace(q{>>Matched subrule: [pragma]<< (return value: [}
-                    . $_tok . q{]},
-
-                      Parse::RecDescent::_tracefirst($text),
-                      q{_alternation_1_of_production_1_of_rule_use_stuff},
-                      $tracelevel)
-                        if defined $::RD_TRACE;
-        $item{q{pragma}} = $_tok;
-        push @item, $_tok;
-        
-        }
-
-        Parse::RecDescent::_trace(q{>>Matched production: [pragma]<<},
-                      Parse::RecDescent::_tracefirst($text),
-                      q{_alternation_1_of_production_1_of_rule_use_stuff},
-                      $tracelevel)
-                        if defined $::RD_TRACE;
-
-
-
-        $_matched = 1;
-        last;
-    }
-
-
-    while (!$_matched && !$commit)
-    {
-        
         Parse::RecDescent::_trace(q{Trying production: [version]},
                       Parse::RecDescent::_tracefirst($_[1]),
                       q{_alternation_1_of_production_1_of_rule_use_stuff},
                       $tracelevel)
                         if defined $::RD_TRACE;
-        my $thisprod = $thisrule->{"prods"}[3];
+        my $thisprod = $thisrule->{"prods"}[2];
         $text = $_[1];
         my $_savetext;
         @item = (q{_alternation_1_of_production_1_of_rule_use_stuff});
@@ -3751,7 +3504,7 @@ sub Parse::RecDescent::Module::ExtractUse::Grammar::_alternation_1_of_production
                       q{_alternation_1_of_production_1_of_rule_use_stuff},
                       $tracelevel)
                         if defined $::RD_TRACE;
-        my $thisprod = $thisrule->{"prods"}[4];
+        my $thisprod = $thisrule->{"prods"}[3];
         $text = $_[1];
         my $_savetext;
         @item = (q{_alternation_1_of_production_1_of_rule_use_stuff});
@@ -4251,7 +4004,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                                                              'implicit' => undef,
                                                                                                                                              'argcode' => undef,
                                                                                                                                              'lookahead' => 0,
-                                                                                                                                             'line' => 72
+                                                                                                                                             'line' => 69
                                                                                                                                            }, 'Parse::RecDescent::Subrule' )
                                                                                                                                   ],
                                                                                                                        'line' => undef
@@ -4271,10 +4024,10 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                                                              'implicit' => undef,
                                                                                                                                              'argcode' => undef,
                                                                                                                                              'lookahead' => 0,
-                                                                                                                                             'line' => 72
+                                                                                                                                             'line' => 69
                                                                                                                                            }, 'Parse::RecDescent::Subrule' )
                                                                                                                                   ],
-                                                                                                                       'line' => 72
+                                                                                                                       'line' => 69
                                                                                                                      }, 'Parse::RecDescent::Production' ),
                                                                                                               bless( {
                                                                                                                        'number' => 2,
@@ -4291,15 +4044,15 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                                                              'implicit' => undef,
                                                                                                                                              'argcode' => undef,
                                                                                                                                              'lookahead' => 0,
-                                                                                                                                             'line' => 72
+                                                                                                                                             'line' => 69
                                                                                                                                            }, 'Parse::RecDescent::Subrule' )
                                                                                                                                   ],
-                                                                                                                       'line' => 72
+                                                                                                                       'line' => 69
                                                                                                                      }, 'Parse::RecDescent::Production' )
                                                                                                             ],
                                                                                                  'name' => '_alternation_1_of_production_1_of_rule_require_stuff',
                                                                                                  'vars' => '',
-                                                                                                 'line' => 72
+                                                                                                 'line' => 69
                                                                                                }, 'Parse::RecDescent::Rule' ),
                               'eos' => bless( {
                                                 'impcount' => 0,
@@ -4319,7 +4072,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                    bless( {
                                                                                             'hashname' => '__ACTION1__',
                                                                                             'lookahead' => 0,
-                                                                                            'line' => 48,
+                                                                                            'line' => 45,
                                                                                             'code' => '{ $text=~/^[\\s;]+$/ ? 1 : undef;}'
                                                                                           }, 'Parse::RecDescent::Action' )
                                                                                  ],
@@ -4328,7 +4081,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                            ],
                                                 'name' => 'eos',
                                                 'vars' => '',
-                                                'line' => 48
+                                                'line' => 45
                                               }, 'Parse::RecDescent::Rule' ),
                               'token_use' => bless( {
                                                       'impcount' => 0,
@@ -4408,7 +4161,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                   'hashname' => '__DIRECTIVE1__',
                                                                                                   'name' => '<perl_quotelike>',
                                                                                                   'lookahead' => 0,
-                                                                                                  'line' => 62,
+                                                                                                  'line' => 59,
                                                                                                   'code' => 'my ($match,@res);
                      ($match,$text,undef,@res) =
                           Text::Balanced::extract_quotelike($text,$skip);
@@ -4418,7 +4171,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                          bless( {
                                                                                                   'hashname' => '__ACTION1__',
                                                                                                   'lookahead' => 0,
-                                                                                                  'line' => 62,
+                                                                                                  'line' => 59,
                                                                                                   'code' => '{ $return=$item[1][2] }'
                                                                                                 }, 'Parse::RecDescent::Action' )
                                                                                        ],
@@ -4437,18 +4190,18 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                   'hashname' => '__DIRECTIVE1__',
                                                                                                   'name' => '<perl_codeblock>',
                                                                                                   'lookahead' => 0,
-                                                                                                  'line' => 64,
+                                                                                                  'line' => 61,
                                                                                                   'code' => 'Text::Balanced::extract_codeblock($text,undef,$skip,\'(){}[]\');
                     '
                                                                                                 }, 'Parse::RecDescent::Directive' ),
                                                                                          bless( {
                                                                                                   'hashname' => '__ACTION1__',
                                                                                                   'lookahead' => 0,
-                                                                                                  'line' => 64,
+                                                                                                  'line' => 61,
                                                                                                   'code' => '{ $return=$item[1] }'
                                                                                                 }, 'Parse::RecDescent::Action' )
                                                                                        ],
-                                                                            'line' => 63
+                                                                            'line' => 60
                                                                           }, 'Parse::RecDescent::Production' ),
                                                                    bless( {
                                                                             'number' => 2,
@@ -4465,23 +4218,23 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                   'description' => '/-?\\\\w+/',
                                                                                                   'lookahead' => 0,
                                                                                                   'rdelim' => '/',
-                                                                                                  'line' => 66,
+                                                                                                  'line' => 63,
                                                                                                   'mod' => '',
                                                                                                   'ldelim' => '/'
                                                                                                 }, 'Parse::RecDescent::Token' ),
                                                                                          bless( {
                                                                                                   'hashname' => '__ACTION1__',
                                                                                                   'lookahead' => 0,
-                                                                                                  'line' => 66,
+                                                                                                  'line' => 63,
                                                                                                   'code' => '{ $return=$item[1] }'
                                                                                                 }, 'Parse::RecDescent::Action' )
                                                                                        ],
-                                                                            'line' => 65
+                                                                            'line' => 62
                                                                           }, 'Parse::RecDescent::Production' )
                                                                  ],
                                                       'name' => 'list_item',
                                                       'vars' => '',
-                                                      'line' => 62
+                                                      'line' => 59
                                                     }, 'Parse::RecDescent::Rule' ),
                               'comma_list_item' => bless( {
                                                             'impcount' => 0,
@@ -4507,7 +4260,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                         'implicit' => undef,
                                                                                                         'argcode' => undef,
                                                                                                         'lookahead' => 0,
-                                                                                                        'line' => 68
+                                                                                                        'line' => 65
                                                                                                       }, 'Parse::RecDescent::Subrule' ),
                                                                                                bless( {
                                                                                                         'subrule' => 'list_item',
@@ -4515,12 +4268,12 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                         'implicit' => undef,
                                                                                                         'argcode' => undef,
                                                                                                         'lookahead' => 0,
-                                                                                                        'line' => 68
+                                                                                                        'line' => 65
                                                                                                       }, 'Parse::RecDescent::Subrule' ),
                                                                                                bless( {
                                                                                                         'hashname' => '__ACTION1__',
                                                                                                         'lookahead' => 0,
-                                                                                                        'line' => 69,
+                                                                                                        'line' => 66,
                                                                                                         'code' => '{ $return=$item{list_item} }'
                                                                                                       }, 'Parse::RecDescent::Action' )
                                                                                              ],
@@ -4529,57 +4282,8 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                        ],
                                                             'name' => 'comma_list_item',
                                                             'vars' => '',
-                                                            'line' => 68
+                                                            'line' => 65
                                                           }, 'Parse::RecDescent::Rule' ),
-                              'pragma' => bless( {
-                                                   'impcount' => 0,
-                                                   'calls' => [
-                                                                'import_list'
-                                                              ],
-                                                   'changed' => 0,
-                                                   'opcount' => 0,
-                                                   'prods' => [
-                                                                bless( {
-                                                                         'number' => 0,
-                                                                         'strcount' => 0,
-                                                                         'dircount' => 0,
-                                                                         'uncommit' => undef,
-                                                                         'error' => undef,
-                                                                         'patcount' => 1,
-                                                                         'actcount' => 1,
-                                                                         'items' => [
-                                                                                      bless( {
-                                                                                               'pattern' => '[a-z\\d]+',
-                                                                                               'hashname' => '__PATTERN1__',
-                                                                                               'description' => '/[a-z\\\\d]+/',
-                                                                                               'lookahead' => 0,
-                                                                                               'rdelim' => '/',
-                                                                                               'line' => 15,
-                                                                                               'mod' => '',
-                                                                                               'ldelim' => '/'
-                                                                                             }, 'Parse::RecDescent::Token' ),
-                                                                                      bless( {
-                                                                                               'subrule' => 'import_list',
-                                                                                               'matchrule' => 0,
-                                                                                               'implicit' => undef,
-                                                                                               'argcode' => undef,
-                                                                                               'lookahead' => 0,
-                                                                                               'line' => 15
-                                                                                             }, 'Parse::RecDescent::Subrule' ),
-                                                                                      bless( {
-                                                                                               'hashname' => '__ACTION1__',
-                                                                                               'lookahead' => 0,
-                                                                                               'line' => 16,
-                                                                                               'code' => '{ $return=$item[1]}'
-                                                                                             }, 'Parse::RecDescent::Action' )
-                                                                                    ],
-                                                                         'line' => undef
-                                                                       }, 'Parse::RecDescent::Production' )
-                                                              ],
-                                                   'name' => 'pragma',
-                                                   'vars' => '',
-                                                   'line' => 15
-                                                 }, 'Parse::RecDescent::Rule' ),
                               'module_more' => bless( {
                                                         'impcount' => 0,
                                                         'calls' => [
@@ -4606,7 +4310,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                     'implicit' => undef,
                                                                                                     'argcode' => undef,
                                                                                                     'lookahead' => 0,
-                                                                                                    'line' => 23
+                                                                                                    'line' => 20
                                                                                                   }, 'Parse::RecDescent::Subrule' )
                                                                                          ],
                                                                               'line' => undef
@@ -4629,7 +4333,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                     'matchrule' => 0,
                                                                                                     'repspec' => '?',
                                                                                                     'lookahead' => 0,
-                                                                                                    'line' => 23
+                                                                                                    'line' => 20
                                                                                                   }, 'Parse::RecDescent::Repetition' ),
                                                                                            bless( {
                                                                                                     'subrule' => 'var',
@@ -4640,7 +4344,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                     'matchrule' => 0,
                                                                                                     'repspec' => '?',
                                                                                                     'lookahead' => 0,
-                                                                                                    'line' => 23
+                                                                                                    'line' => 20
                                                                                                   }, 'Parse::RecDescent::Repetition' ),
                                                                                            bless( {
                                                                                                     'subrule' => 'import_list',
@@ -4651,15 +4355,15 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                     'matchrule' => 0,
                                                                                                     'repspec' => '?',
                                                                                                     'lookahead' => 0,
-                                                                                                    'line' => 23
+                                                                                                    'line' => 20
                                                                                                   }, 'Parse::RecDescent::Repetition' )
                                                                                          ],
-                                                                              'line' => 23
+                                                                              'line' => 20
                                                                             }, 'Parse::RecDescent::Production' )
                                                                    ],
                                                         'name' => 'module_more',
                                                         'vars' => '',
-                                                        'line' => 23
+                                                        'line' => 20
                                                       }, 'Parse::RecDescent::Rule' ),
                               'module_name' => bless( {
                                                         'impcount' => 0,
@@ -4682,7 +4386,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                     'description' => '/[\\\\w:]+/',
                                                                                                     'lookahead' => 0,
                                                                                                     'rdelim' => '/',
-                                                                                                    'line' => 21,
+                                                                                                    'line' => 18,
                                                                                                     'mod' => '',
                                                                                                     'ldelim' => '/'
                                                                                                   }, 'Parse::RecDescent::Token' )
@@ -4692,7 +4396,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                    ],
                                                         'name' => 'module_name',
                                                         'vars' => '',
-                                                        'line' => 21
+                                                        'line' => 18
                                                       }, 'Parse::RecDescent::Rule' ),
                               'var' => bless( {
                                                 'impcount' => 0,
@@ -4715,7 +4419,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                             'description' => '/\\\\$[\\\\w+]/',
                                                                                             'lookahead' => 0,
                                                                                             'rdelim' => '/',
-                                                                                            'line' => 50,
+                                                                                            'line' => 47,
                                                                                             'mod' => '',
                                                                                             'ldelim' => '/'
                                                                                           }, 'Parse::RecDescent::Token' )
@@ -4725,7 +4429,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                            ],
                                                 'name' => 'var',
                                                 'vars' => '',
-                                                'line' => 50
+                                                'line' => 47
                                               }, 'Parse::RecDescent::Rule' ),
                               'module' => bless( {
                                                    'impcount' => 0,
@@ -4751,7 +4455,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                'implicit' => undef,
                                                                                                'argcode' => undef,
                                                                                                'lookahead' => 0,
-                                                                                               'line' => 18
+                                                                                               'line' => 15
                                                                                              }, 'Parse::RecDescent::Subrule' ),
                                                                                       bless( {
                                                                                                'subrule' => 'module_more',
@@ -4759,12 +4463,12 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                'implicit' => undef,
                                                                                                'argcode' => undef,
                                                                                                'lookahead' => 0,
-                                                                                               'line' => 18
+                                                                                               'line' => 15
                                                                                              }, 'Parse::RecDescent::Subrule' ),
                                                                                       bless( {
                                                                                                'hashname' => '__ACTION1__',
                                                                                                'lookahead' => 0,
-                                                                                               'line' => 19,
+                                                                                               'line' => 16,
                                                                                                'code' => '{ $return=$item{module_name} }'
                                                                                              }, 'Parse::RecDescent::Action' )
                                                                                     ],
@@ -4773,7 +4477,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                               ],
                                                    'name' => 'module',
                                                    'vars' => '',
-                                                   'line' => 18
+                                                   'line' => 15
                                                  }, 'Parse::RecDescent::Rule' ),
                               '_alternation_1_of_production_1_of_rule_comma' => bless( {
                                                                                          'impcount' => 0,
@@ -4795,7 +4499,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                                                      'hashname' => '__STRING1__',
                                                                                                                                      'description' => '\',\'',
                                                                                                                                      'lookahead' => 0,
-                                                                                                                                     'line' => 72
+                                                                                                                                     'line' => 69
                                                                                                                                    }, 'Parse::RecDescent::Literal' )
                                                                                                                           ],
                                                                                                                'line' => undef
@@ -4814,15 +4518,15 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                                                      'hashname' => '__STRING1__',
                                                                                                                                      'description' => '\'=>\'',
                                                                                                                                      'lookahead' => 0,
-                                                                                                                                     'line' => 72
+                                                                                                                                     'line' => 69
                                                                                                                                    }, 'Parse::RecDescent::Literal' )
                                                                                                                           ],
-                                                                                                               'line' => 72
+                                                                                                               'line' => 69
                                                                                                              }, 'Parse::RecDescent::Production' )
                                                                                                     ],
                                                                                          'name' => '_alternation_1_of_production_1_of_rule_comma',
                                                                                          'vars' => '',
-                                                                                         'line' => 72
+                                                                                         'line' => 69
                                                                                        }, 'Parse::RecDescent::Rule' ),
                               'base' => bless( {
                                                  'impcount' => 0,
@@ -4933,7 +4637,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                       'implicit' => 'version, or require_name, or module',
                                                                                                       'argcode' => undef,
                                                                                                       'lookahead' => 0,
-                                                                                                      'line' => 32
+                                                                                                      'line' => 29
                                                                                                     }, 'Parse::RecDescent::Subrule' )
                                                                                            ],
                                                                                 'line' => undef
@@ -4941,7 +4645,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                      ],
                                                           'name' => 'require_stuff',
                                                           'vars' => '',
-                                                          'line' => 32
+                                                          'line' => 29
                                                         }, 'Parse::RecDescent::Rule' ),
                               'comma' => bless( {
                                                   'impcount' => 1,
@@ -4966,7 +4670,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                               'implicit' => '\',\', or \'=>\'',
                                                                                               'argcode' => undef,
                                                                                               'lookahead' => 0,
-                                                                                              'line' => 71
+                                                                                              'line' => 68
                                                                                             }, 'Parse::RecDescent::Subrule' )
                                                                                    ],
                                                                         'line' => undef
@@ -4974,7 +4678,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                              ],
                                                   'name' => 'comma',
                                                   'vars' => '',
-                                                  'line' => 71
+                                                  'line' => 68
                                                 }, 'Parse::RecDescent::Rule' ),
                               'version' => bless( {
                                                     'impcount' => 0,
@@ -4992,12 +4696,12 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                           'actcount' => 0,
                                                                           'items' => [
                                                                                        bless( {
-                                                                                                'pattern' => '[\\d\\._v]+',
+                                                                                                'pattern' => 'v?[\\d\\._]+',
                                                                                                 'hashname' => '__PATTERN1__',
-                                                                                                'description' => '/[\\\\d\\\\._v]+/',
+                                                                                                'description' => '/v?[\\\\d\\\\._]+/',
                                                                                                 'lookahead' => 0,
                                                                                                 'rdelim' => '/',
-                                                                                                'line' => 46,
+                                                                                                'line' => 43,
                                                                                                 'mod' => '',
                                                                                                 'ldelim' => '/'
                                                                                               }, 'Parse::RecDescent::Token' )
@@ -5007,7 +4711,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                ],
                                                     'name' => 'version',
                                                     'vars' => '',
-                                                    'line' => 44
+                                                    'line' => 41
                                                   }, 'Parse::RecDescent::Rule' ),
                               'use_stuff' => bless( {
                                                       'impcount' => 1,
@@ -5029,7 +4733,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                          bless( {
                                                                                                   'subrule' => '_alternation_1_of_production_1_of_rule_use_stuff',
                                                                                                   'matchrule' => 0,
-                                                                                                  'implicit' => 'base, or parent, or pragma, or version, or module',
+                                                                                                  'implicit' => 'base, or parent, or version, or module',
                                                                                                   'argcode' => undef,
                                                                                                   'lookahead' => 0,
                                                                                                   'line' => 8
@@ -5066,7 +4770,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                     'description' => '/[(]?/',
                                                                                                     'lookahead' => 0,
                                                                                                     'rdelim' => '/',
-                                                                                                    'line' => 52,
+                                                                                                    'line' => 49,
                                                                                                     'mod' => '',
                                                                                                     'ldelim' => '/'
                                                                                                   }, 'Parse::RecDescent::Token' ),
@@ -5076,7 +4780,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                     'implicit' => undef,
                                                                                                     'argcode' => undef,
                                                                                                     'lookahead' => 0,
-                                                                                                    'line' => 53
+                                                                                                    'line' => 50
                                                                                                   }, 'Parse::RecDescent::Subrule' ),
                                                                                            bless( {
                                                                                                     'subrule' => 'comma_list_item',
@@ -5087,7 +4791,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                     'matchrule' => 0,
                                                                                                     'repspec' => 's?',
                                                                                                     'lookahead' => 0,
-                                                                                                    'line' => 54
+                                                                                                    'line' => 51
                                                                                                   }, 'Parse::RecDescent::Repetition' ),
                                                                                            bless( {
                                                                                                     'pattern' => '[)]?',
@@ -5095,14 +4799,14 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                     'description' => '/[)]?/',
                                                                                                     'lookahead' => 0,
                                                                                                     'rdelim' => '/',
-                                                                                                    'line' => 55,
+                                                                                                    'line' => 52,
                                                                                                     'mod' => '',
                                                                                                     'ldelim' => '/'
                                                                                                   }, 'Parse::RecDescent::Token' ),
                                                                                            bless( {
                                                                                                     'hashname' => '__ACTION1__',
                                                                                                     'lookahead' => 0,
-                                                                                                    'line' => 56,
+                                                                                                    'line' => 53,
                                                                                                     'code' => '{ $return=$item[2];
 		  $return.=" ".join(" ",@{$item[3]}) if $item[3];
 		}'
@@ -5125,30 +4829,29 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                     'description' => '/[(]\\\\s*[)]/',
                                                                                                     'lookahead' => 0,
                                                                                                     'rdelim' => '/',
-                                                                                                    'line' => 60,
+                                                                                                    'line' => 57,
                                                                                                     'mod' => '',
                                                                                                     'ldelim' => '/'
                                                                                                   }, 'Parse::RecDescent::Token' ),
                                                                                            bless( {
                                                                                                     'hashname' => '__ACTION1__',
                                                                                                     'lookahead' => 0,
-                                                                                                    'line' => 60,
+                                                                                                    'line' => 57,
                                                                                                     'code' => '{ $return=\'\' }'
                                                                                                   }, 'Parse::RecDescent::Action' )
                                                                                          ],
-                                                                              'line' => 59
+                                                                              'line' => 56
                                                                             }, 'Parse::RecDescent::Production' )
                                                                    ],
                                                         'name' => 'import_list',
                                                         'vars' => '',
-                                                        'line' => 52
+                                                        'line' => 49
                                                       }, 'Parse::RecDescent::Rule' ),
                               '_alternation_1_of_production_1_of_rule_use_stuff' => bless( {
                                                                                              'impcount' => 0,
                                                                                              'calls' => [
                                                                                                           'base',
                                                                                                           'parent',
-                                                                                                          'pragma',
                                                                                                           'version',
                                                                                                           'module'
                                                                                                         ],
@@ -5170,7 +4873,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                                                          'implicit' => undef,
                                                                                                                                          'argcode' => undef,
                                                                                                                                          'lookahead' => 0,
-                                                                                                                                         'line' => 72
+                                                                                                                                         'line' => 69
                                                                                                                                        }, 'Parse::RecDescent::Subrule' )
                                                                                                                               ],
                                                                                                                    'line' => undef
@@ -5190,33 +4893,13 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                                                          'implicit' => undef,
                                                                                                                                          'argcode' => undef,
                                                                                                                                          'lookahead' => 0,
-                                                                                                                                         'line' => 72
+                                                                                                                                         'line' => 69
                                                                                                                                        }, 'Parse::RecDescent::Subrule' )
                                                                                                                               ],
-                                                                                                                   'line' => 72
+                                                                                                                   'line' => 69
                                                                                                                  }, 'Parse::RecDescent::Production' ),
                                                                                                           bless( {
                                                                                                                    'number' => 2,
-                                                                                                                   'strcount' => 0,
-                                                                                                                   'dircount' => 0,
-                                                                                                                   'uncommit' => undef,
-                                                                                                                   'error' => undef,
-                                                                                                                   'patcount' => 0,
-                                                                                                                   'actcount' => 0,
-                                                                                                                   'items' => [
-                                                                                                                                bless( {
-                                                                                                                                         'subrule' => 'pragma',
-                                                                                                                                         'matchrule' => 0,
-                                                                                                                                         'implicit' => undef,
-                                                                                                                                         'argcode' => undef,
-                                                                                                                                         'lookahead' => 0,
-                                                                                                                                         'line' => 72
-                                                                                                                                       }, 'Parse::RecDescent::Subrule' )
-                                                                                                                              ],
-                                                                                                                   'line' => 72
-                                                                                                                 }, 'Parse::RecDescent::Production' ),
-                                                                                                          bless( {
-                                                                                                                   'number' => 3,
                                                                                                                    'strcount' => 0,
                                                                                                                    'dircount' => 0,
                                                                                                                    'uncommit' => undef,
@@ -5230,13 +4913,13 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                                                          'implicit' => undef,
                                                                                                                                          'argcode' => undef,
                                                                                                                                          'lookahead' => 0,
-                                                                                                                                         'line' => 72
+                                                                                                                                         'line' => 69
                                                                                                                                        }, 'Parse::RecDescent::Subrule' )
                                                                                                                               ],
-                                                                                                                   'line' => 72
+                                                                                                                   'line' => 69
                                                                                                                  }, 'Parse::RecDescent::Production' ),
                                                                                                           bless( {
-                                                                                                                   'number' => 4,
+                                                                                                                   'number' => 3,
                                                                                                                    'strcount' => 0,
                                                                                                                    'dircount' => 0,
                                                                                                                    'uncommit' => undef,
@@ -5250,15 +4933,15 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                                                          'implicit' => undef,
                                                                                                                                          'argcode' => undef,
                                                                                                                                          'lookahead' => 0,
-                                                                                                                                         'line' => 72
+                                                                                                                                         'line' => 69
                                                                                                                                        }, 'Parse::RecDescent::Subrule' )
                                                                                                                               ],
-                                                                                                                   'line' => 72
+                                                                                                                   'line' => 69
                                                                                                                  }, 'Parse::RecDescent::Production' )
                                                                                                         ],
                                                                                              'name' => '_alternation_1_of_production_1_of_rule_use_stuff',
                                                                                              'vars' => '',
-                                                                                             'line' => 72
+                                                                                             'line' => 69
                                                                                            }, 'Parse::RecDescent::Rule' ),
                               'token_require' => bless( {
                                                           'impcount' => 0,
@@ -5283,7 +4966,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                       'description' => '/\\\\brequire\\\\s/',
                                                                                                       'lookahead' => 0,
                                                                                                       'rdelim' => '/',
-                                                                                                      'line' => 29,
+                                                                                                      'line' => 26,
                                                                                                       'mod' => '',
                                                                                                       'ldelim' => '/'
                                                                                                     }, 'Parse::RecDescent::Token' ),
@@ -5293,7 +4976,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                       'implicit' => undef,
                                                                                                       'argcode' => undef,
                                                                                                       'lookahead' => 0,
-                                                                                                      'line' => 29
+                                                                                                      'line' => 26
                                                                                                     }, 'Parse::RecDescent::Subrule' ),
                                                                                              bless( {
                                                                                                       'pattern' => '[;}]',
@@ -5301,14 +4984,14 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                       'description' => '/[;\\}]/',
                                                                                                       'lookahead' => 0,
                                                                                                       'rdelim' => '/',
-                                                                                                      'line' => 29,
+                                                                                                      'line' => 26,
                                                                                                       'mod' => '',
                                                                                                       'ldelim' => '/'
                                                                                                     }, 'Parse::RecDescent::Token' ),
                                                                                              bless( {
                                                                                                       'hashname' => '__ACTION1__',
                                                                                                       'lookahead' => 0,
-                                                                                                      'line' => 30,
+                                                                                                      'line' => 27,
                                                                                                       'code' => '{ $return=$item{require_stuff} }'
                                                                                                     }, 'Parse::RecDescent::Action' )
                                                                                            ],
@@ -5317,7 +5000,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                      ],
                                                           'name' => 'token_require',
                                                           'vars' => '',
-                                                          'line' => 27
+                                                          'line' => 24
                                                         }, 'Parse::RecDescent::Rule' ),
                               'require_name' => bless( {
                                                          'impcount' => 0,
@@ -5338,7 +5021,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                                      'hashname' => '__DIRECTIVE1__',
                                                                                                      'name' => '<perl_quotelike>',
                                                                                                      'lookahead' => 0,
-                                                                                                     'line' => 34,
+                                                                                                     'line' => 31,
                                                                                                      'code' => 'my ($match,@res);
                      ($match,$text,undef,@res) =
                           Text::Balanced::extract_quotelike($text,$skip);
@@ -5348,7 +5031,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                                             bless( {
                                                                                                      'hashname' => '__ACTION1__',
                                                                                                      'lookahead' => 0,
-                                                                                                     'line' => 35,
+                                                                                                     'line' => 32,
                                                                                                      'code' => '{ my $name=$item[1][2];
 		  return 1 if ($name=~/\\.pl$/);
 		  $name=~s(/)(::)g;
@@ -5362,7 +5045,7 @@ package Module::ExtractUse::Grammar; sub new { my $self = bless( {
                                                                     ],
                                                          'name' => 'require_name',
                                                          'vars' => '',
-                                                         'line' => 34
+                                                         'line' => 31
                                                        }, 'Parse::RecDescent::Rule' )
                             },
                  '_AUTOTREE' => undef,

--- a/t/10_basic.t
+++ b/t/10_basic.t
@@ -100,6 +100,8 @@ Test::Pod::all_pod_files_ok( 'lib', -d $generated_pod_dir ? $generated_pod_dir :
 ['use MooseX::Types -declare => [qw(BorderStyle Component Container)];',[qw(MooseX::Types)],undef,[qw(MooseX::Types)]],
 ['eval { require Foo::Bar32 };',[qw(Foo::Bar32)],[qw(Foo::Bar32)],undef],
 ['do { use Foo::Bar33 };',[qw(Foo::Bar33)],undef,[qw(Foo::Bar33)]],
+['use version;',[qw(version)],undef,[qw(version)]],
+['use version 0.77;',[qw(version)],undef,[qw(version)]],
 );
 
 

--- a/t/20_parse_self.t
+++ b/t/20_parse_self.t
@@ -30,13 +30,13 @@ use Module::ExtractUse;
     my $p=Module::ExtractUse->new;
     $p->extract_use('lib/Module/ExtractUse.pm');
     cmp_deeply($p->arrayref,
-	       bag(qw(strict warnings Pod::Strip Parse::RecDescent Module::ExtractUse::Grammar Carp 5.008)),
+	       bag(qw(strict version warnings Pod::Strip Parse::RecDescent Module::ExtractUse::Grammar Carp 5.008)),
 	       'modules used in this Module::ExtractUsed');
     cmp_deeply([$p->arrayref_in_eval],
 	       [],
 	       'optional modules used in this Module::ExtractUsed');
     cmp_deeply($p->arrayref_out_of_eval,
-	       bag(qw(strict warnings Pod::Strip Parse::RecDescent Module::ExtractUse::Grammar Carp 5.008)),
+	       bag(qw(strict version warnings Pod::Strip Parse::RecDescent Module::ExtractUse::Grammar Carp 5.008)),
 	       'mandatory modules used in this Module::ExtractUsed');
 
     my $used=$p->used;
@@ -55,6 +55,4 @@ use Module::ExtractUse;
     is($p->used_out_of_eval('strict'),1,'strict via used_out_of_eval method');
 
 }
-
-
 


### PR DESCRIPTION
The following 2 issues are fixed by this pull request. Both are related with using `version` pragma.
- module beginning with v
- pragma with version requirement

Please note that `t/20_parse_self.t` is also adjusted because `version` is ignored in the test.

Details are as follows:
- module beginning with v
  - **Issue:** For example, for the case of `use version`, just a letter `'v'` is matched to the rule `<version>` and the rest, `'ersion'` is left. The rule `<use_stuff>` is matched because the rule `<version>` is matched but the regex `/[;}]/` in the rule `<token_use>` is not matched to `'ersion'`. Thus, the rule `<token_use>` fails to match completely (don't backtrack).
  - **Fix:** Adjust regexp of `<version>` not to match to words like `'version'`.
- pragma with version requirement
  - **Issue:** Even after the above fix, `use version 0.77` can not be detected. Trying to match to the rule `<pragma>`, the rule `<import_list>` is matched to just a letter `'0'` then `<token_use>` fails the way similar to above.
  - **Fix:** Remove the rule `<pragma>` to fall back to the rule `<module>`. I think this is fair because a pragma is just a module.
