### PR TITLE
Handle Class::Load

### DIFF
--- a/grammar
+++ b/grammar
@@ -46,6 +46,34 @@ token_no:		/\bno\s/ no_stuff /[;}]/
 no_stuff:	(base | version | module)
 
 #-----------------------------------------------------------------
+# Functions provided by Class::Load
+#-----------------------------------------------------------------
+
+hash_pair: /\S+/ comma ( <perl_quotelike> | /\S+/ )
+
+comma_hash_pair: comma hash_pair
+
+hashref:    '{' hash_pair comma_hash_pair(s?) '}'
+
+comma_hashref:  comma hashref
+
+class_load_functions:   'load_class' | 'try_load_class' | 'load_optional_class'
+
+class_load:     ( ( 'Class::Load::' class_load_functions ) | ( /\b/ class_load_functions ) ) '(' <perl_quotelike> comma_hashref(?) ')'
+                { $return = $item[3][2] }
+
+first_existing_arg: <perl_quotelike> comma_hashref(?)
+                    { $return = $item[1][2] }
+
+comma_first_existing_arg:   comma first_existing_arg
+                            { $return = $item{first_existing_arg} }
+
+class_load_first_existing:  ( 'Class::Load::load_first_existing' /\bload_first_existing/ ) '(' first_existing_arg comma_first_existing_arg(s?) ')'
+                            { $return = $item{import_list} }
+
+token_class_load:   class_load | class_load_first_existing
+
+#-----------------------------------------------------------------
 # General Rules
 #-----------------------------------------------------------------
 

--- a/grammar
+++ b/grammar
@@ -49,7 +49,7 @@ no_stuff:	(base | version | module)
 # Functions provided by Class::Load
 #-----------------------------------------------------------------
 
-hash_pair: /\S+/ comma ( <perl_quotelike> | /\S+/ )
+hash_pair: /\S+/ comma ( <perl_quotelike> | /[^\s,}]+/ )
 
 comma_hash_pair: comma hash_pair
 
@@ -68,8 +68,11 @@ first_existing_arg: <perl_quotelike> comma_hashref(?)
 comma_first_existing_arg:   comma first_existing_arg
                             { $return = $item{first_existing_arg} }
 
-class_load_first_existing:  ( 'Class::Load::load_first_existing' /\bload_first_existing/ ) '(' first_existing_arg comma_first_existing_arg(s?) ')'
-                            { $return = $item{import_list} }
+class_load_first_existing:  ( 'Class::Load::load_first_existing_class' | /\bload_first_existing_class/ ) '(' first_existing_arg comma_first_existing_arg(s?) ')'
+                            { $return = $item{first_existing_arg};
+                              $return .= " " . join(" ", @{$item{'comma_first_existing_arg(s?)'}}) if $item{'comma_first_existing_arg(s?)'};
+                              1;
+                            }
 
 token_class_load:   class_load | class_load_first_existing
 

--- a/lib/Module/ExtractUse.pm
+++ b/lib/Module/ExtractUse.pm
@@ -221,6 +221,15 @@ sub extract_use {
             };
             $type = 'no';
         }
+        elsif ($statement=~m/load_class|try_load_class|load_first_existing_class|load_optional_class/) {
+            $statement=~s/^(.*?)\b(\S+(?:load_class|try_load_class|load_first_existing_class|load_optional_class)\([^)]*\))/$2/;
+            next if $1 && $1 =~ /->\s*$/;
+            eval {
+                my $parser=Module::ExtractUse::Grammar->new();
+                $result = $parser->token_class_load($statement.';');
+            };
+            $type = 'require';
+        }
 
         next unless $result;
 

--- a/t/28_class_load.t
+++ b/t/28_class_load.t
@@ -1,0 +1,52 @@
+#!/usr/bin/perl -w
+use strict;
+use Test::More;
+use Test::Deep;
+use Test::NoWarnings;
+use Module::ExtractUse;
+
+my @tests=
+  (
+#1
+   ['load_class("Some::Module");',[qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['load_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['Class::Load::load_class("Some::Module");',[qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['Class::Load::load_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
+
+   ['try_load_class("Some::Module");',[qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['try_load_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['Class::Load::try_load_class("Some::Module");',[qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['Class::Load::try_load_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
+
+   ['load_optional_class("Some::Module");',[qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['load_optional_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['Class::Load::load_optional_class("Some::Module");',[qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['Class::Load::load_optional_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
+);
+
+
+plan tests => (scalar @tests)*3+1;
+
+
+foreach my $t (@tests) {
+    my ($code, @expected)=@$t;
+    my $p=Module::ExtractUse->new;
+    my @used = (
+        $p->extract_use(\$code)->arrayref || undef,
+        $p->extract_use(\$code)->arrayref_in_eval || undef,
+        $p->extract_use(\$code)->arrayref_out_of_eval || undef,
+    );
+
+    for(my $i = 0; $i < @used; ++$i) {
+        if (ref($expected[$i]) eq 'ARRAY') {
+            cmp_bag($used[$i]||[],$expected[$i],$i.": ".$code);
+        } elsif (!defined $expected[$i]) {
+            is(undef,$used[$i],$i.": ".$code);
+        } else {
+            is($used[$i],$expected[$i],$i.": ".$code);
+        }
+    }
+}
+
+
+

--- a/t/28_class_load.t
+++ b/t/28_class_load.t
@@ -14,7 +14,7 @@ my @tests=
    ['Class::Load::load_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
 
    ['try_load_class("Some::Module");',[qw(Some::Module)],undef,[qw(Some::Module)]],
-   ['try_load_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['try_load_class("Some::Module", { -version => 1.23, other => "string" });',[qw(Some::Module)],undef,[qw(Some::Module)]],
    ['Class::Load::try_load_class("Some::Module");',[qw(Some::Module)],undef,[qw(Some::Module)]],
    ['Class::Load::try_load_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
 
@@ -22,6 +22,20 @@ my @tests=
    ['load_optional_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
    ['Class::Load::load_optional_class("Some::Module");',[qw(Some::Module)],undef,[qw(Some::Module)]],
    ['Class::Load::load_optional_class("Some::Module", { -version => 1.23 });',[qw(Some::Module)],undef,[qw(Some::Module)]],
+
+   ['load_first_existing_class("Some::Module");', [qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['load_first_existing_class("Some::Module", "Other::Module", "Third::Module::Too");', [qw(Some::Module Other::Module Third::Module::Too)],undef,[qw(Some::Module Other::Module Third::Module::Too)]],
+   ['load_first_existing_class("Some::Module", { -version => 1.23 });', [qw(Some::Module)],undef,[qw(Some::Module)]],
+   ['load_first_existing_class("Some::Module", { -version => 1.23 }, "Other::Module", "Third::Module::Too", { -version => 4.56 } );', [qw(Some::Module Other::Module Third::Module::Too)],undef,[qw(Some::Module Other::Module Third::Module::Too)]],
+
+    ['$foo->load_class("Some::Module")', undef, undef, undef],
+    ['Other::Namespace::load_class("Some::Module")', undef, undef, undef],
+    ['$foo->try_load_class("Some::Module")', undef, undef, undef],
+    ['Other::Namespace::try_load_class("Some::Module")', undef, undef, undef],
+    ['$foo->load_optional_class("Some::Module")', undef, undef, undef],
+    ['Other::Namespace::load_optional_class("Some::Module")', undef, undef, undef],
+    ['$foo->load_first_existing_class("Some::Module")', undef, undef, undef],
+    ['Other::Namespace::load_first_existing_class("Some::Module")', undef, undef, undef],
 );
 
 
@@ -31,6 +45,7 @@ plan tests => (scalar @tests)*3+1;
 foreach my $t (@tests) {
     my ($code, @expected)=@$t;
     my $p=Module::ExtractUse->new;
+
     my @used = (
         $p->extract_use(\$code)->arrayref || undef,
         $p->extract_use(\$code)->arrayref_in_eval || undef,


### PR DESCRIPTION
Augment the grammar to detect modules loaded via Class::Load

I didn't include the changes to Module::ExtractUse::Grammar to limit the conflicts if this PR and #14 are both merged.  The grammar module will need to be re-generated before you can test or release.