### PR TITLE
Mention Perl::PrereqScanner modules family

### DIFF
--- a/lib/Module/ExtractUse.pm
+++ b/lib/Module/ExtractUse.pm
@@ -555,7 +555,7 @@ Nothing.
 
 =head1 SEE ALSO
 
-L<Parse::RecDescent>, L<Module::Extract::Use>, L<Module::ScanDeps>, L<Module::Info>, L<Module::CPANTS::Analyse>
+L<Parse::RecDescent>, L<Module::Extract::Use>, L<Module::ScanDeps>, L<Module::Info>, L<Module::CPANTS::Analyse>, L<Perl::PrereqScanner>, L<Perl::PrereqScanner::Lite>, L<Perl::PrereqScanner::NotQuiteLite>
 
 =head1 CONTRIBUTORS
 


### PR DESCRIPTION
Since you are already mentioning other similar modules, including modules that accomplish the same goal with different approach, I think it's appropriate to mention "the big elephant in the room": Perl::PrereqScanner::* modules.