### PR TITLE
Ignore module names containing the dollar sign

### DIFF
--- a/lib/Module/ExtractUse.pm
+++ b/lib/Module/ExtractUse.pm
@@ -243,7 +243,7 @@ sub extract_use {
         next unless $result;
 
         foreach (split(/\s+/,$result)) {
-            $self->_add($_, $eval, $type) if($_);
+            $self->_add($_, $eval, $type) if( $_ && ! /\$/ );
         }
     }
 

--- a/t/29_variable.t
+++ b/t/29_variable.t
@@ -1,0 +1,17 @@
+#!/usr/bin/perl -w
+use strict;
+use Test::More;
+use Test::NoWarnings;
+use Module::ExtractUse;
+
+plan tests => 3 + 1;
+
+# Text::ANSITable
+my $code = 'require "Text/ANSITable/StyleSet/$name.pm";';
+
+my $p = Module::ExtractUse->new;
+$p->extract_use(\$code);
+
+ok( ! $p->used( 'Text::ANSITable::StyleSet::$name' ) );
+ok( ! $p->used_in_eval( 'Text::ANSITable::StyleSet::$name' ) );
+ok( ! $p->used_out_of_eval( 'Text::ANSITable::StyleSet::$name' ) );


### PR DESCRIPTION
If the syntax is OK, the dollar sign comes from a variable name, so we don't know what module is being requried.

Fixes https://rt.cpan.org/Ticket/Display.html?id=127269